### PR TITLE
Use Files.move instead of File#renameTo

### DIFF
--- a/Grimoire-shared/src/main/java/io/github/crucible/omniconfig/OmniconfigCore.java
+++ b/Grimoire-shared/src/main/java/io/github/crucible/omniconfig/OmniconfigCore.java
@@ -107,9 +107,12 @@ public class OmniconfigCore {
         tempFile.delete();
 
         // For the time of writing, preserve old archive as temporary file
-        boolean renameOk = zipFile.renameTo(tempFile);
-        if (!renameOk)
-            throw new RuntimeException("Could not rename the file " + zipFile.getAbsolutePath() + " to " + tempFile.getAbsolutePath());
+        try {
+            Files.move(zipFile.toPath(), tempFile.toPath());
+        } catch(IOException e) {
+            throw new RuntimeException("Could not rename the file " + zipFile.getAbsolutePath() + " to " + tempFile.getAbsolutePath(), e);
+        }
+
         byte[] buf = new byte[1024];
 
         ZipInputStream zipInput = new ZipInputStream(new FileInputStream(tempFile));


### PR DESCRIPTION
On Linux `File.createTempFile` creates a file in the /tmp directory, which often resides on a separate filesystem, and as such, trying to move `defaultconfigs` to it with `File#renameTo` will fail. Using `Files.move` solves this issue.